### PR TITLE
Return dict objects and add child method

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,5 +1,4 @@
 import pyfire
-import pyfire.utils as utils
 import config
 
 # Example use of Pyfire
@@ -7,8 +6,8 @@ import config
 # Set URL endpoint and secret key (respectively) to the Firebase realtime database
 Pyfire = pyfire.Pyfire(config.FIREBASE_DATABASE_URL, config.FIREBASE_DATABASE_SECRET)
 
-new_object = Pyfire.post({'Foo': 'Bar'}) # Post an object to the Firebase realtime database. The object will be assigned an unique key. EG: "-KLYFXcwUO-rKJMwrT0F" and the stored object is returned
-new_object_name = utils.get_property_from_json_string('name', new_object) # Get the random key generated for the above object (can be used to add further children by changing the relative path to this)
+new_object = Pyfire.post({'Foo': 'Bar'})  # Post an object to the Firebase realtime database. The object will be assigned an unique key. EG: "-KLYFXcwUO-rKJMwrT0F" and the stored object is returned
+new_object_name = new_object['name']  # Get the random key generated for the above object (can be used to add further children by changing the relative path to this)
 
 Pyfire.set_endpoint_path(new_object_name) # Set path to the key of the item just created
 
@@ -19,4 +18,14 @@ Pyfire.patch({'more': 'data'})  # Add a new object into current path. This does 
 print Pyfire.set_endpoint_path('').get()  # Set endpoint path back to the root and get the contents. (This line demonstrates how certain request can be chained)
 
 # Get entity (user) with a specific value (abcdefg) for a specified key (prop_name)
-print Pyfire.set_endpoint_path('user').order_by("prop_name").equal_to("abcdefg").get()
+print Pyfire.set_endpoint_path('user').order_by("access_code").equal_to("abcdefg").get()
+
+Pyfire.set_endpoint_path('')  # reset path for example to make more sense
+
+# Use child method with variable amount of arguments
+print Pyfire.child('user', '-KLn5QoiyCLp3UQTIhXL', 'email_address').get()
+
+Pyfire.set_endpoint_path('')  # reset path for example to make more sense
+
+# Child with just one arg
+print Pyfire.child('user').get()

--- a/pyfire/__init__.py
+++ b/pyfire/__init__.py
@@ -28,33 +28,38 @@ class Pyfire:
         self.database_secret = secret
         return self
 
+    def child(self, *args):
+        path = "/".join(args)
+        self.endpoint_path += "/{}".format(path)
+        return self
+
     # GET - Reading data
     # The response will contain all the data under the specified endpoint path
     def get(self):
-        return self._execute("GET", {})
+        return json.loads(self._execute("GET", {}))
 
     # PUT - Writing Data:
     # This will override everything under the current working path with the object specified
     def put(self, data):
-        return self._execute("PUT", data)
+        return json.loads(self._execute("PUT", data))
 
     # POST - Pushing Data
     # This will create a new object at the current path with a new unique key.
     # The response will contain the newly created object (along with its generated key (its 'name' attribute)
     def post(self, data):
-        return self._execute("POST", data)
+        return json.loads(self._execute("POST", data))
 
     # PATCH - Updating Data
     # We can update specific children at a location without overwriting existing data using a PATCH request.
     # Named children in the data being written with PATCH will be overwritten, but omitted children will not be deleted.
     # A successful request will be indicated by a 200 OK HTTP status code. The response will contain the data written:
     def patch(self, data):
-        return self._execute("PATCH", data)
+        return json.loads(self._execute("PATCH", data))
 
     # DELETE - Removing Data
-    # Deletes everyhing under the current path
+    # Deletes everything under the current path
     def delete(self):
-        return self._execute("DELETE", {})
+        return json.loads(self._execute("DELETE", {}))
 
     def order_by(self, order_by):
         self.query_params["orderBy"] = order_by
@@ -68,17 +73,22 @@ class Pyfire:
         request_url = self.root_data_url + self.endpoint_path + '.json?'
         query_string = None
 
+        # IF a firebase database secret is set, append it to the query as the 'auth' query param
         if self.database_secret:
             request_url += 'auth=' + self.database_secret
 
+        # Has the user specified any extra query params?
         if self.query_params:
             query_string = "&"
+            # Add the order by param,
+            # Reason for the weird selection of quotes below is that the param must be wrapped in double quotes
             if self.query_params.get('orderBy'):
                 query_string += 'orderBy=\"'+self.query_params.get('orderBy')+'\"'
-                # Can only use equalTo with orderBy, so nest if statement
+                # Firebase can only use equalTo ALONG with orderBy, so nest if statement withing the order by one
                 if self.query_params.get('equalTo'):
                     query_string += '&equalTo=\"'+self.query_params.get('equalTo')+'\"'
 
+        # IF we've built a query string above, add it to the request url
         if query_string:
             request_url += query_string
 

--- a/pyfire/utils.py
+++ b/pyfire/utils.py
@@ -1,5 +1,0 @@
-import json
-
-
-def get_property_from_json_string(prop_name, json_string):
-    return json.loads(json_string)[prop_name]


### PR DESCRIPTION
Make the http request wrappers return a dict (json.loads()) as opposed to a json string.
Add the child method to allow for changing the endpoint path in a more semantic way
